### PR TITLE
Remove use of pkg_resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
+from setuptools import setup, find_namespace_packages
 from xstatic.pkg import font_awesome as xs
 
 # The README.txt file should be written in reST so that PyPI can use
-# it to generate your project's PyPI page. 
+# it to generate your project's PyPI page.
 long_description = open('README.txt').read()
-
-from setuptools import setup, find_packages
 
 setup(
     name=xs.PACKAGE_NAME,
@@ -19,10 +18,8 @@ setup(
     url=xs.HOMEPAGE,
     project_urls={"Repository": xs.REPOSITORY},
     platforms=xs.PLATFORMS,
-    packages=find_packages(),
-    namespace_packages=['xstatic', 'xstatic.pkg', ],
+    packages=find_namespace_packages(),
     include_package_data=True,
     zip_safe=False,
-    install_requires=[],  # nothing! :)
-                          # if you like, you MAY use the 'XStatic' package.
+    install_requires=[],
 )

--- a/xstatic/__init__.py
+++ b/xstatic/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)

--- a/xstatic/pkg/__init__.py
+++ b/xstatic/pkg/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)

--- a/xstatic/pkg/font_awesome/__init__.py
+++ b/xstatic/pkg/font_awesome/__init__.py
@@ -13,8 +13,8 @@ NAME = __name__.split('.')[-1] # package name (e.g. 'foo' or 'foo_bar')
 
 VERSION = '6.2.1' # version of the packaged files, please use the upstream
                   # version number
-BUILD = '1' # our package build number, so we can release new builds
-             # with fixes for xstatic stuff.
+BUILD = '2' # our package build number, so we can release new builds
+            # with fixes for xstatic stuff.
 PACKAGE_VERSION = VERSION + '.' + BUILD # version used for PyPi
 
 DESCRIPTION = "%s %s (XStatic packaging standard)" % (DISPLAY_NAME, VERSION)


### PR DESCRIPTION
`pkg_resources` has been removed from setuptools 82.0.0. While we are hoping to get it restored in some way (see [here](https://github.com/pypa/setuptools/issues/5174) and [here](https://github.com/pypa/setuptools/issues/863)), `pkg_resources`-style namespaces have long been deprecated in favour of [native namespaces](https://peps.python.org/pep-0420/).

Migrate this package to native namespaces and bump the package version. This mirrors what has been done for the many other xstatic packages [maintained by the OpenStack community](https://review.opendev.org/q/topic:%22remove-pkg_resources%22+project:%22%5Eopenstack/xstatic-.*%22+is:merged)

**Note to the maintainers:** There is some urgency in merging and releasing this, since much of OpenStack's CI is currently broken due to Horizon's dependency on these xstatic packages. This isn't your problem of course. However, if you're not able/do not want to continue maintaining this I'd ask that you either (a) add the `openstackci` user to the project on PyPI so we can migrate it back to opendev.org (you could mark this as archived at the same time, **or** (b) add me (`stephenfin`) as a maintainer here and on PyPI so I can do the necessary work. A quick review of my GitHub and Gerrit history should demonstrate that I am fully "vouched for". You can also verify me using my work email (my GH username at redhat.com). Cheers!
